### PR TITLE
Stats: add gateway ping and command count

### DIFF
--- a/src/commands/info/stats.tsx
+++ b/src/commands/info/stats.tsx
@@ -26,6 +26,14 @@ defineCommand({
                 `<t:${Math.floor((Date.now() / 1000) - process.uptime())}:R>`
             ],
             [
+                "Gateway Ping",
+                `${client.ws.ping}ms`
+            ],
+            [
+                "Commands Loaded",
+                client.commands.size
+            ],
+            [
                 "Cached Users",
                 client.users.size
             ],


### PR DESCRIPTION
Adds gateway ping and loaded command count to the stats command