### PR TITLE
add helpers mute/sticky & new modmail category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ data
 
 .env
 config.ts
+
+.DS_Store

--- a/assets/examples/config.example.ts
+++ b/assets/examples/config.example.ts
@@ -33,7 +33,8 @@ const Config = {
     "roles": {
         // anyone with this role can execute moderation commands
         "mod": "1026509424686284924",
-
+        // anyone with this role has limited access to moderation commands like mute
+        "helper": "1244313853357981787",
         // used for github linking and some other things
         "donor": "1042507929485586532",
         // used for github linking and some other things

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -91,16 +91,11 @@ async function handleMessage(msg: Message, isEdit: boolean) {
             return;
     }
 
-    if (cmd.modOnly || cmd.helperOnly) {
+    if (cmd.requiredRoles) {
         if (!msg.inCachedGuildChannel()) return;
 
-        const hasHelper = msg.member.roles.includes(Config.roles.helper);
-        const hasMod = msg.member.roles.includes(Config.roles.mod);
-
-        if (cmd.helperOnly && !(hasHelper || hasMod))
-            return silently(msg.createReaction(Emoji.Anger));
-
-        if (cmd.modOnly && !(hasMod || hasHelper))
+        const memberRoles = msg.member.roles;
+        if (cmd.requiredRoles.every(role => !memberRoles.includes(role)))
             return silently(msg.createReaction(Emoji.Anger));
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -91,10 +91,16 @@ async function handleMessage(msg: Message, isEdit: boolean) {
             return;
     }
 
-    if (cmd.modOnly) {
+    if (cmd.modOnly || cmd.helperOnly) {
         if (!msg.inCachedGuildChannel()) return;
 
-        if (!msg.member.roles.includes(Config.roles.mod))
+        const hasHelper = msg.member.roles.includes(Config.roles.helper);
+        const hasMod = msg.member.roles.includes(Config.roles.mod);
+
+        if (cmd.helperOnly && !(hasHelper || hasMod))
+            return silently(msg.createReaction(Emoji.Anger));
+
+        if (cmd.modOnly && !(hasMod || hasHelper))
             return silently(msg.createReaction(Emoji.Anger));
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -91,11 +91,10 @@ async function handleMessage(msg: Message, isEdit: boolean) {
             return;
     }
 
-    if (cmd.requiredRoles) {
+    if (cmd.allowedRoles) {
         if (!msg.inCachedGuildChannel()) return;
 
-        const memberRoles = msg.member.roles;
-        if (cmd.requiredRoles.every(role => !memberRoles.includes(role)))
+        if (!cmd.allowedRoles.some(role => msg.member.roles.includes(role)))
             return silently(msg.createReaction(Emoji.Anger));
     }
 

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -106,8 +106,7 @@ export interface Command<GuildOnly extends boolean = false> {
     guildOnly?: GuildOnly;
     permissions?: Array<PermissionName>,
     ownerOnly?: boolean;
-    modOnly?: boolean;
-    helperOnly?: boolean;
+    requiredRoles?: string[];
     enabled?: boolean;
     rawContent?: boolean;
     rateLimit?: number;

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -107,6 +107,7 @@ export interface Command<GuildOnly extends boolean = false> {
     permissions?: Array<PermissionName>,
     ownerOnly?: boolean;
     modOnly?: boolean;
+    helperOnly?: boolean;
     enabled?: boolean;
     rawContent?: boolean;
     rateLimit?: number;

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -106,7 +106,7 @@ export interface Command<GuildOnly extends boolean = false> {
     guildOnly?: GuildOnly;
     permissions?: Array<PermissionName>,
     ownerOnly?: boolean;
-    requiredRoles?: string[];
+    allowedRoles?: string[];
     enabled?: boolean;
     rawContent?: boolean;
     rateLimit?: number;

--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -8,7 +8,7 @@ import Config from "./config";
 interface BaseInteractionHandler {
     ownerOnly?: boolean;
     guildOnly?: boolean;
-    modOnly?: boolean;
+    requiredRoles?: string[];
 }
 interface AnyInteractionHandler extends BaseInteractionHandler {
     handle(interaction: AnyInteractionGateway): any;
@@ -85,10 +85,12 @@ Vaius.on("interactionCreate", async interaction => {
     if (!handler) return;
     if (handler.ownerOnly && interaction.user.id !== OwnerId) return;
     if (handler.guildOnly && !interaction.inCachedGuildChannel()) return;
-    if (handler.modOnly) {
-        if (!interaction.inCachedGuildChannel()) return;
+    if (handler.requiredRoles && !interaction.inCachedGuildChannel()) return;
 
-        if (!interaction.member.roles.includes(Config.roles.mod))
+    if (handler.requiredRoles) {
+        const memberRoles = interaction.member?.roles;
+
+        if (handler.requiredRoles.every(r => !memberRoles?.includes(r)))
             return;
     }
 

--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -8,7 +8,7 @@ import Config from "./config";
 interface BaseInteractionHandler {
     ownerOnly?: boolean;
     guildOnly?: boolean;
-    requiredRoles?: string[];
+    allowedRoles?: string[];
 }
 interface AnyInteractionHandler extends BaseInteractionHandler {
     handle(interaction: AnyInteractionGateway): any;
@@ -85,12 +85,11 @@ Vaius.on("interactionCreate", async interaction => {
     if (!handler) return;
     if (handler.ownerOnly && interaction.user.id !== OwnerId) return;
     if (handler.guildOnly && !interaction.inCachedGuildChannel()) return;
-    if (handler.requiredRoles && !interaction.inCachedGuildChannel()) return;
 
-    if (handler.requiredRoles) {
-        const memberRoles = interaction.member?.roles;
+    if (handler.allowedRoles) {
+        if (!interaction.inCachedGuildChannel()) return;
 
-        if (handler.requiredRoles.every(r => !memberRoles?.includes(r)))
+        if (!handler.allowedRoles.some(r => interaction.member.roles.includes(r)))
             return;
     }
 

--- a/src/commands/cotd/reroll-cotd.tsx
+++ b/src/commands/cotd/reroll-cotd.tsx
@@ -1,6 +1,7 @@
 import { ButtonStyles, CreateMessageOptions, EditMessageOptions, User } from "oceanic.js";
 
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Emoji } from "~/constants";
 import { drawBlobCatCozy, rerollCotd } from "~/modules/regularCotd";
 import { handleComponentInteraction } from "~/SlashCommands";
@@ -46,7 +47,7 @@ defineCommand({
     description: "Rerolls the current cozy of the day",
     usage: "[hex]",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ reply }, hex?: string) {
         if (hex) {
             const parsed = Number(hex.replace(/^#/, "0x"));
@@ -66,7 +67,7 @@ defineCommand({
 handleComponentInteraction({
     customID: "reroll-cotd",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async handle(interaction) {
         const result = await reroll(undefined, interaction.user);
         await interaction.editParent(result);

--- a/src/commands/cotd/reroll-cotd.tsx
+++ b/src/commands/cotd/reroll-cotd.tsx
@@ -47,7 +47,7 @@ defineCommand({
     description: "Rerolls the current cozy of the day",
     usage: "[hex]",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ reply }, hex?: string) {
         if (hex === "#ffbce0") return;
 
@@ -69,7 +69,7 @@ defineCommand({
 handleComponentInteraction({
     customID: "reroll-cotd",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async handle(interaction) {
         const result = await reroll(undefined, interaction.user);
         await interaction.editParent(result);

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "~/Commands";
 import Config from "~/config";
-import { Emoji } from "~/constants";
+import { Emoji, SUPPORT_ALLOWED_CHANNELS } from "~/constants";
 import { BotState } from "~/db/botState";
 import { StickyState } from "~/modules/sticky";
 import { toCodeblock } from "~/util/text";
@@ -13,6 +13,14 @@ defineCommand({
     usage: "<create/set | delete/remove | on | off | delay | list> [value]",
     rawContent: true,
     execute({ reply, react, msg, prefix, commandName }, content) {
+
+        if (
+            msg.member.roles.includes(Config.roles.helper) &&
+            !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
+        ) {
+            return reply("For support helpers, this command can only be used in support channels");
+        }
+
         let response: string | undefined;
 
         const [operation, value, ...extra] = content.split(" ");

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -8,6 +8,7 @@ defineCommand({
     name: "sticky",
     description: "Set the sticky message",
     modOnly: true,
+    helperOnly: true,
     guildOnly: true,
     usage: "<create/set | delete/remove | on | off | delay | list> [value]",
     rawContent: true,

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Emoji } from "~/constants";
 import { BotState } from "~/db/botState";
 import { StickyState } from "~/modules/sticky";
@@ -7,8 +8,7 @@ import { toCodeblock } from "~/util/text";
 defineCommand({
     name: "sticky",
     description: "Set the sticky message",
-    modOnly: true,
-    helperOnly: true,
+    requiredRoles: [Config.roles.mod, Config.roles.helper],
     guildOnly: true,
     usage: "<create/set | delete/remove | on | off | delay | list> [value]",
     rawContent: true,

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -16,6 +16,7 @@ defineCommand({
 
         if (
             msg.member.roles.includes(Config.roles.helper) &&
+            !msg.member.roles.includes(Config.roles.mod) &&
             !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
         ) {
             return reply("For support helpers, this command can only be used in support channels");

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -1,8 +1,9 @@
 import { defineCommand } from "~/Commands";
 import Config from "~/config";
-import { Emoji, SUPPORT_ALLOWED_CHANNELS } from "~/constants";
+import { Emoji } from "~/constants";
 import { BotState } from "~/db/botState";
 import { StickyState } from "~/modules/sticky";
+import { isSupportHelperOutsideSupport } from "~/util/discord";
 import { toCodeblock } from "~/util/text";
 
 defineCommand({
@@ -13,12 +14,7 @@ defineCommand({
     usage: "<create/set | delete/remove | on | off | delay | list> [value]",
     rawContent: true,
     execute({ reply, react, msg, prefix, commandName }, content) {
-
-        if (
-            msg.member.roles.includes(Config.roles.helper) &&
-            !msg.member.roles.includes(Config.roles.mod) &&
-            !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
-        ) {
+        if (isSupportHelperOutsideSupport(msg.member, msg.channelID)) {
             return reply("For support helpers, this command can only be used in support channels");
         }
 

--- a/src/commands/dev/sticky.ts
+++ b/src/commands/dev/sticky.ts
@@ -8,7 +8,7 @@ import { toCodeblock } from "~/util/text";
 defineCommand({
     name: "sticky",
     description: "Set the sticky message",
-    requiredRoles: [Config.roles.mod, Config.roles.helper],
+    allowedRoles: [Config.roles.mod, Config.roles.helper],
     guildOnly: true,
     usage: "<create/set | delete/remove | on | off | delay | list> [value]",
     rawContent: true,

--- a/src/commands/info/help.tsx
+++ b/src/commands/info/help.tsx
@@ -118,7 +118,9 @@ function commandHelp(cmd: FullCommand, { prefix }: CommandContext) {
             : ""
         }
         ${cmd.guildOnly ? "`🏠` This command can only be used in servers" : ""}
-        ${cmd.modOnly ? "`🔨` This command can only be used by server moderators" : ""}
+        ${cmd.requiredRoles
+            ? `\`🔨\` This command can only be used by roles: ${cmd.requiredRoles.map(role => `<@&${role}>`).join(", ")}`
+            : ""}
     `;
 
     return (

--- a/src/commands/info/help.tsx
+++ b/src/commands/info/help.tsx
@@ -118,8 +118,8 @@ function commandHelp(cmd: FullCommand, { prefix }: CommandContext) {
             : ""
         }
         ${cmd.guildOnly ? "`🏠` This command can only be used in servers" : ""}
-        ${cmd.requiredRoles
-            ? `\`🔨\` This command can only be used by roles: ${cmd.requiredRoles.map(role => `<@&${role}>`).join(", ")}`
+        ${cmd.allowedRoles
+            ? `\`🔨\` This command can only be used by roles: ${cmd.allowedRoles.map(role => `<@&${role}>`).join(", ")}`
             : ""}
     `;
 

--- a/src/commands/misc/vencord-reporter.ts
+++ b/src/commands/misc/vencord-reporter.ts
@@ -12,7 +12,7 @@ defineCommand({
     description: "Run the Vencord reporter workflow",
     usage: "[ref = dev] [branch = both]",
     aliases: ["report", "vencord-reporter", "test-patches", "test"],
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
 
     async execute({ msg }, ref = DefaultReporterBranch, branch = "both") {
         testDiscordVersion(

--- a/src/commands/misc/vencord-reporter.ts
+++ b/src/commands/misc/vencord-reporter.ts
@@ -12,7 +12,7 @@ defineCommand({
     description: "Run the Vencord reporter workflow",
     usage: "[ref = dev] [branch = both]",
     aliases: ["report", "vencord-reporter", "test-patches", "test"],
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
 
     async execute({ msg }, ref = DefaultReporterBranch, branch = "both") {
         testDiscordVersion(

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -1,6 +1,7 @@
 import { AnyTextableGuildChannel, Member, Message, MessageTypes } from "oceanic.js";
 
 import { CommandContext, defineCommand } from "~/Commands";
+import Config from "~/config";
 import { silently } from "~/util/functions";
 import { toCodeblock } from "~/util/text";
 
@@ -125,7 +126,7 @@ defineCommand({
     usage: "[daysToDelete] <user> [user...] [reason]",
     aliases: ["yeet", "🍌"],
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     execute: (ctx, ...args) => banExecutor(ctx, args, false)
 });
 
@@ -135,6 +136,6 @@ defineCommand({
     usage: "<daysToDelete> <user> [user...] [reason]",
     aliases: ["sb"],
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     execute: (ctx, ...args) => banExecutor(ctx, args, true)
 });

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -126,7 +126,7 @@ defineCommand({
     usage: "[daysToDelete] <user> [user...] [reason]",
     aliases: ["yeet", "🍌"],
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     execute: (ctx, ...args) => banExecutor(ctx, args, false)
 });
 
@@ -136,6 +136,6 @@ defineCommand({
     usage: "<daysToDelete> <user> [user...] [reason]",
     aliases: ["sb"],
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     execute: (ctx, ...args) => banExecutor(ctx, args, true)
 });

--- a/src/commands/moderation/editChannel.ts
+++ b/src/commands/moderation/editChannel.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Emoji } from "~/constants";
 import { reply } from "~/util/discord";
 
@@ -8,7 +9,7 @@ defineCommand({
     usage: "<value>",
     aliases: ["setname", "sn", "rename"],
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     rawContent: true,
     async execute({ msg, react }, value) {
         if (!value)
@@ -28,7 +29,7 @@ defineCommand({
     usage: "<value>",
     aliases: ["settopic"],
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     rawContent: true,
     async execute({ msg, react, reply }, value) {
         if (!value)

--- a/src/commands/moderation/editChannel.ts
+++ b/src/commands/moderation/editChannel.ts
@@ -9,7 +9,7 @@ defineCommand({
     usage: "<value>",
     aliases: ["setname", "sn", "rename"],
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     rawContent: true,
     async execute({ msg, react }, value) {
         if (!value)
@@ -29,7 +29,7 @@ defineCommand({
     usage: "<value>",
     aliases: ["settopic"],
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     rawContent: true,
     async execute({ msg, react, reply }, value) {
         if (!value)

--- a/src/commands/moderation/modifyRoles.ts
+++ b/src/commands/moderation/modifyRoles.ts
@@ -60,7 +60,7 @@ defineCommand({
     description: "Add a role to one or more users",
     usage: "<role> <user> [user...]",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, ...args) {
         const { role, users } = parseArgs(msg, args);
         if (!role) return react(Emoji.QuestionMark);
@@ -84,7 +84,7 @@ defineCommand({
     description: "Remove a role from one or more users",
     usage: "<role> <user> [user...]",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, reply, react }, ...args) {
         const { role, users } = parseArgs(msg, args);
         if (!role) return react(Emoji.QuestionMark);

--- a/src/commands/moderation/modifyRoles.ts
+++ b/src/commands/moderation/modifyRoles.ts
@@ -60,7 +60,7 @@ defineCommand({
     description: "Add a role to one or more users",
     usage: "<role> <user> [user...]",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, ...args) {
         const { role, users } = parseArgs(msg, args);
         if (!role) return react(Emoji.QuestionMark);
@@ -84,7 +84,7 @@ defineCommand({
     description: "Remove a role from one or more users",
     usage: "<role> <user> [user...]",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, reply, react }, ...args) {
         const { role, users } = parseArgs(msg, args);
         if (!role) return react(Emoji.QuestionMark);

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -1,6 +1,7 @@
 import parseDuration from "parse-duration";
 
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Millis } from "~/constants";
 import { silently } from "~/util/functions";
 import { msToHumanReadable, toCodeblock } from "~/util/text";
@@ -15,11 +16,18 @@ defineCommand({
     usage: "<duration> <user> [user...] [reason]",
     guildOnly: true,
     modOnly: true,
+    helperOnly: true,
     async execute({ msg, reply }, durationString, ...args) {
         const duration = parseDuration(durationString);
-        if (duration == null || duration < 1 || duration > 28 * Millis.DAY) {
-            return reply("Duration must be a valid time span not longer than 28 days");
+
+        const durationLimits = (msg.member.roles.includes(Config.roles.mod))
+            ? 28 * Millis.DAY
+            : 3 * Millis.HOUR;
+
+        if (duration == null || duration < 1 || duration > durationLimits) {
+            return reply(`Duration must be a valid time span not longer than ${msToHumanReadable(durationLimits)}`);
         }
+
         const durationText = msToHumanReadable(duration);
 
 

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -15,8 +15,7 @@ defineCommand({
     description: "Mute one or more users",
     usage: "<duration> <user> [user...] [reason]",
     guildOnly: true,
-    modOnly: true,
-    helperOnly: true,
+    requiredRoles: [Config.roles.mod, Config.roles.helper],
     async execute({ msg, reply }, durationString, ...args) {
         const duration = parseDuration(durationString);
 

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -2,7 +2,7 @@ import parseDuration from "parse-duration";
 
 import { defineCommand } from "~/Commands";
 import Config from "~/config";
-import { Millis } from "~/constants";
+import { Millis, SUPPORT_ALLOWED_CHANNELS } from "~/constants";
 import { silently } from "~/util/functions";
 import { msToHumanReadable, toCodeblock } from "~/util/text";
 import { until } from "~/util/time";
@@ -19,16 +19,24 @@ defineCommand({
     async execute({ msg, reply }, durationString, ...args) {
         const duration = parseDuration(durationString);
 
-        const durationLimits = (msg.member.roles.includes(Config.roles.mod))
+        if (
+            msg.member.roles.includes(Config.roles.helper) &&
+            !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
+        ) {
+            return reply("For support helpers, this command can only be used in support channels");
+        }
+
+        const maxDuration = (msg.member.roles.includes(Config.roles.mod))
             ? 28 * Millis.DAY
             : 3 * Millis.HOUR;
 
-        if (duration == null || duration < 1 || duration > durationLimits) {
-            return reply(`Duration must be a valid time span not longer than ${msToHumanReadable(durationLimits)}`);
+        const minDuration = 1 * Millis.HOUR;
+
+        if (duration == null || duration < minDuration || duration > maxDuration) {
+            return reply(`Duration must be between ${msToHumanReadable(minDuration)} and ${msToHumanReadable(maxDuration)}`);
         }
 
         const durationText = msToHumanReadable(duration);
-
 
         let { ids, reason, hasCustomReason } = parseUserIdsAndReason(args);
         if (!ids.length && msg.referencedMessage) {

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -15,7 +15,7 @@ defineCommand({
     description: "Mute one or more users",
     usage: "<duration> <user> [user...] [reason]",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod, Config.roles.helper],
+    allowedRoles: [Config.roles.mod, Config.roles.helper],
     async execute({ msg, reply }, durationString, ...args) {
         const duration = parseDuration(durationString);
 

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -21,6 +21,7 @@ defineCommand({
 
         if (
             msg.member.roles.includes(Config.roles.helper) &&
+            !msg.member.roles.includes(Config.roles.mod) &&
             !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
         ) {
             return reply("For support helpers, this command can only be used in support channels");

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -31,10 +31,8 @@ defineCommand({
             ? 28 * Millis.DAY
             : 3 * Millis.HOUR;
 
-        const minDuration = 1 * Millis.HOUR;
-
-        if (duration == null || duration < minDuration || duration > maxDuration) {
-            return reply(`Duration must be between ${msToHumanReadable(minDuration)} and ${msToHumanReadable(maxDuration)}`);
+        if (duration == null || duration < 1 || duration > maxDuration) {
+            return reply(`Duration must be ${msToHumanReadable(maxDuration)} or less`);
         }
 
         const durationText = msToHumanReadable(duration);

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -2,11 +2,12 @@ import parseDuration from "parse-duration";
 
 import { defineCommand } from "~/Commands";
 import Config from "~/config";
-import { Millis, SUPPORT_ALLOWED_CHANNELS } from "~/constants";
+import { Millis } from "~/constants";
 import { silently } from "~/util/functions";
 import { msToHumanReadable, toCodeblock } from "~/util/text";
 import { until } from "~/util/time";
 
+import { isSupportHelperOutsideSupport } from "~/util/discord";
 import { getHighestRolePosition, logUserRestriction, ModerationColor, parseUserIdsAndReason } from "./utils";
 
 defineCommand({
@@ -17,17 +18,13 @@ defineCommand({
     guildOnly: true,
     allowedRoles: [Config.roles.mod, Config.roles.helper],
     async execute({ msg, reply }, durationString, ...args) {
-        const duration = parseDuration(durationString);
-
-        if (
-            msg.member.roles.includes(Config.roles.helper) &&
-            !msg.member.roles.includes(Config.roles.mod) &&
-            !SUPPORT_ALLOWED_CHANNELS.includes(msg.channelID)
-        ) {
+        if (isSupportHelperOutsideSupport(msg.member, msg.channelID)) {
             return reply("For support helpers, this command can only be used in support channels");
         }
 
-        const maxDuration = (msg.member.roles.includes(Config.roles.mod))
+        const duration = parseDuration(durationString);
+
+        const maxDuration = msg.member.roles.includes(Config.roles.mod)
             ? 28 * Millis.DAY
             : 3 * Millis.HOUR;
 

--- a/src/commands/moderation/slowmode.ts
+++ b/src/commands/moderation/slowmode.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Emoji } from "~/constants";
 import { reply } from "~/util/discord";
 
@@ -8,7 +9,7 @@ defineCommand({
     description: "Set the slowmode for the channel",
     usage: "<seconds>",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, react }, secondsArg) {
         if (secondsArg === "off") secondsArg = "0";
 

--- a/src/commands/moderation/slowmode.ts
+++ b/src/commands/moderation/slowmode.ts
@@ -9,7 +9,7 @@ defineCommand({
     description: "Set the slowmode for the channel",
     usage: "<seconds>",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, react }, secondsArg) {
         if (secondsArg === "off") secondsArg = "0";
 

--- a/src/commands/moderation/submission-pass.ts
+++ b/src/commands/moderation/submission-pass.ts
@@ -32,7 +32,7 @@ defineCommand({
     description: "Allow this user to post one submission",
     usage: "<user>",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, user) {
         const id = resolveUserId(user);
         if (!id)
@@ -52,7 +52,7 @@ defineCommand({
     description: "Remove this user's submission pass",
     usage: "<user>",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, user) {
         const id = resolveUserId(user);
         if (!id)

--- a/src/commands/moderation/submission-pass.ts
+++ b/src/commands/moderation/submission-pass.ts
@@ -32,7 +32,7 @@ defineCommand({
     description: "Allow this user to post one submission",
     usage: "<user>",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, user) {
         const id = resolveUserId(user);
         if (!id)
@@ -52,7 +52,7 @@ defineCommand({
     description: "Remove this user's submission pass",
     usage: "<user>",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, react, reply }, user) {
         const id = resolveUserId(user);
         if (!id)

--- a/src/commands/moderation/unban.ts
+++ b/src/commands/moderation/unban.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "~/Commands";
 
+import Config from "~/config";
 import { logUserRestriction, ModerationColor, parseUserIdsAndReason } from "./utils";
 
 defineCommand({
@@ -8,7 +9,7 @@ defineCommand({
     usage: "<user> [user...] [reason]",
     aliases: ["unyeet", "🍌💥"],
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
     async execute({ msg, reply }, ...args) {
         const { ids, reason } = parseUserIdsAndReason(args);
 

--- a/src/commands/moderation/unban.ts
+++ b/src/commands/moderation/unban.ts
@@ -9,7 +9,7 @@ defineCommand({
     usage: "<user> [user...] [reason]",
     aliases: ["unyeet", "🍌💥"],
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
     async execute({ msg, reply }, ...args) {
         const { ids, reason } = parseUserIdsAndReason(args);
 

--- a/src/commands/moderation/watchThreads.ts
+++ b/src/commands/moderation/watchThreads.ts
@@ -2,6 +2,7 @@ import { AuditLogActionTypes } from "oceanic.js";
 
 import { Vaius } from "~/Client";
 import { defineCommand } from "~/Commands";
+import Config from "~/config";
 import { Emoji } from "~/constants";
 import { BotState } from "~/db/botState";
 import { resolveChannel } from "~/util/resolvers";
@@ -12,7 +13,7 @@ defineCommand({
     description: "Watches your threads to make sure they always stay open! Specify a channel to watch all threads in that channel.",
     usage: "<[w]atch|[u]nwatch|[l]ist> [thread|channel]",
     guildOnly: true,
-    modOnly: true,
+    requiredRoles: [Config.roles.mod],
 
     async execute({ reply, react, msg }, action = "list", threadOrChannelResolvable = msg.channelID) {
         action = action.toLowerCase();

--- a/src/commands/moderation/watchThreads.ts
+++ b/src/commands/moderation/watchThreads.ts
@@ -13,7 +13,7 @@ defineCommand({
     description: "Watches your threads to make sure they always stay open! Specify a channel to watch all threads in that channel.",
     usage: "<[w]atch|[u]nwatch|[l]ist> [thread|channel]",
     guildOnly: true,
-    requiredRoles: [Config.roles.mod],
+    allowedRoles: [Config.roles.mod],
 
     async execute({ reply, react, msg }, action = "list", threadOrChannelResolvable = msg.channelID) {
         action = action.toLowerCase();

--- a/src/modules/modmail.tsx
+++ b/src/modules/modmail.tsx
@@ -25,6 +25,7 @@ const enum Ids {
     REASON_MONKEY = "modmail:iamamonkey",
     REASON_MOD = "modmail:mod",
     REASON_DONOR = "modmail:donor",
+    REASON_ACCESS = "modmail:access",
     REASON_PLUGIN = "modmail:plugin",
     REASON_CSS = "modmail:css",
     REASON_JS = "modmail:js"
@@ -32,9 +33,10 @@ const enum Ids {
 
 const ChannelNameAndPrompt: Record<string, [string, string]> = {
     [Ids.REASON_MOD]: ["ticket", "Please post any supporting media or information that you have."],
+    [Ids.REASON_ACCESS]: ["dev-access", "Please post the reason why you want access to development channels."],
     [Ids.REASON_PLUGIN]: ["plugin-submission", "Please post the full message + image(s) that you would like to post in the plugin channel."],
     [Ids.REASON_CSS]: ["css-submission", "Please post the full message + image(s) that you would like to post in the css snippet channel."],
-    [Ids.REASON_JS]: ["js-submission", "Please post the full message + image(s) that you would like to post in the js snippet channel."]
+    [Ids.REASON_JS]: ["js-submission", "Please post the full message + image(s) that you would like to post in the js snippet channel."],
 };
 
 const COMMAND_NAME = PROD ? "modmail" : "devmodmail";
@@ -82,6 +84,11 @@ async function createModmailModal(interaction: GuildInteraction) {
             label: "I need to talk to a moderator",
             value: Ids.REASON_MOD,
             emoji: { name: "👥" }
+        },
+        {
+            label: "I want to access the development channels",
+            value: Ids.REASON_ACCESS,
+            emoji: { name: "👾" }
         },
         {
             label: "I want to submit my css snippet",

--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -3,7 +3,7 @@ import { Client, CreateMessageOptions, DiscordRESTError, Member, Message, Messag
 import { Vaius } from "~/Client";
 
 import Config from "~/config";
-import { Millis } from "~/constants";
+import { Millis, SUPPORT_ALLOWED_CHANNELS } from "~/constants";
 import { silently } from "./functions";
 import { sleep, until } from "./time";
 
@@ -50,6 +50,12 @@ export function getHighestRole({ guild, roles }: Member, filter?: (r: Role) => b
     if (filter) resolvedRoles = resolvedRoles.filter(filter);
 
     return resolvedRoles.reduce((a, b) => a.position > b.position ? a : b);
+}
+
+export function isSupportHelperOutsideSupport({ roles }: Member, channelId: string) {
+    return !SUPPORT_ALLOWED_CHANNELS.includes(channelId)
+        && roles.includes(Config.roles.helper)
+        && !roles.includes(Config.roles.mod);
 }
 
 export const getHomeGuild = () => Vaius.guilds.get(Config.homeGuildId);


### PR DESCRIPTION
## Changes
- Helpers should be allowed to use the mute command instead of the traditional timeout feature, but with a smaller duration as I don't see the need for anything higher.
- Modmail now has a new category for development channel access.